### PR TITLE
Promote to prod environment

### DIFF
--- a/components/nodejs-qsfxjncr/overlays/prod/deployment-patch.yaml
+++ b/components/nodejs-qsfxjncr/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-appstudio/dance-bootstrap-app:latest
+      - image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/nodejs-qsfxjncr:d3468591e4ceee59779d3e945c2adc05f44487cc@sha256:ac02e691ca51af73bae71afa32488381f8ea9f4b4ba7050f30697b0d5b90e5a3
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/nodejs-qsfxjncr:d3468591e4ceee59779d3e945c2adc05f44487cc@sha256:ac02e691ca51af73bae71afa32488381f8ea9f4b4ba7050f30697b0d5b90e5a3